### PR TITLE
Add an API URL route for events.

### DIFF
--- a/txtalert/apps/api/urls.py
+++ b/txtalert/apps/api/urls.py
@@ -7,4 +7,5 @@ from txtalert.apps.api import views
 urlpatterns = patterns(
     '',
     url(r'^pcm\.json$', views.pcm, {}, 'api-pcm'),
+    url(r'^events\.json$', views.events, {}, 'api-events'),
 )

--- a/txtalert/apps/api/views.py
+++ b/txtalert/apps/api/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
-from txtalert.apps.gateway.models import PleaseCallMe
+from txtalert.apps.gateway.models import PleaseCallMe, SendSMS
 
 
 def expect_json(func):
@@ -23,7 +23,6 @@ def expect_json(func):
     return wrapper
 
 
-# @login_required
 @csrf_exempt
 @expect_json
 def pcm(request):
@@ -57,3 +56,23 @@ def pcm(request):
         recipient_msisdn=to_addr or 'default', message=content)
 
     return HttpResponse(status=201, content='Please Call Me registered')
+
+
+@csrf_exempt
+@expect_json
+def events(request):
+    event = request.json
+    identifier = event['user_message_id'][:8]
+    sms = SendSMS.objects.get(identifier=identifier)
+    if event['event_type'] == 'ack':
+        sms.status = 'd'  # sent
+    elif event['event_type'] == 'nack':
+        sms.status = 'F'  # failed
+    elif event['event_type'] == 'delivery_report':
+        sms.status = {
+            'pending': 'd',  # sent
+            'failed': 'F',  # failed
+            'delivered': 'D'  # delivered
+        }.get(event['delivery_status'], 'v')  # unknown
+    sms.save()
+    return HttpResponse(status=201, content='Event registered.')


### PR DESCRIPTION
Currently its configured to receive events in production but the URL its configured to send events too isn't supported.
